### PR TITLE
Fix: issue-#12 - Align "Add to compare" button across product cards

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,0 +1,7 @@
+{
+    "workbench.colorCustomizations": {
+        "activityBar.background": "#51114C",
+        "titleBar.activeBackground": "#71186A",
+        "titleBar.activeForeground": "#FEFCFE"
+    }
+}

--- a/Client/.env.example
+++ b/Client/.env.example
@@ -1,1 +1,1 @@
-VITE_API_URL=https://price-poka-servre.vercel.app
+VITE_API_BASE_URL=https://price-poka-servre.vercel.app

--- a/Client/src/components/Card.jsx
+++ b/Client/src/components/Card.jsx
@@ -22,7 +22,7 @@ export default function Card({ product }) {
   const price = extractNumbersFromString(product?.price);
 
   return (
-    <div className="bg_glass rounded-lg overflow-hidden shadow-md text-prime p-4 space-y-2">
+    <div className="bg_glass rounded-lg overflow-hidden shadow-md text-prime p-4 flex flex-col justify-between">
       <a
         href={product.link}
         target="_blank"
@@ -48,7 +48,7 @@ export default function Card({ product }) {
         </div>
 
         <h6 className="text-xs text-left pt-2">{product?.name}</h6>
-        <p className="text-l font-semibold gradient-text text-left">
+        <p className="text-l font-semibold gradient-text text-left py-2">
           {price === "Out Of Stock" || price === 0
             ? "Out Of Stock"
             : `${price}৳`}


### PR DESCRIPTION
### **Summary:**
This PR fixes the inconsistent alignment of the "Add to compare" button in product cards caused by variable content height (e.g., different product name lengths or price availability).

### **What was done:**

- Ensured product cards maintain a uniform height and the button stays pinned to the bottom of each card.